### PR TITLE
feat: switch nanomatch to micromatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ neat_html:
 ```
 - **enable** - Enable the plugin. Defaults to `true`.
 - **logger** - Verbose output. Defaults to `false`.
-- **exclude** - Exclude files. Support [wildcard](https://github.com/micromatch/nanomatch#features) glob pattern.
+- **exclude** - Exclude files.
   - Support one-liner, `exclude: [*.min.html, *.note.html]`.
   - To exclude a file, double asterisk and the full path must be specified, `**/themes/typing/source/js/source.js`.
   - `*source.js` also works, but it also excludes `resource.js`.
   - Test glob pattern on the web using [Globtester](http://www.globtester.com/).
+- **globOptions** - [micromatch options](https://github.com/micromatch/micromatch#options) to customise how glob patterns match files. Defaults to `{ matchBase: true }`.
 
 For more options, see [HTMLMinifier](https://github.com/kangax/html-minifier).
 
@@ -56,6 +57,7 @@ neat_css:
 - **logger** - Verbose output. Defaults to `false`.
 - **exclude** - Exclude files. Support wildcard pattern.
 - **level** - Optimization level. Defaults to `2`.
+- **globOptions** - [micromatch options](https://github.com/micromatch/micromatch#options) to customise how glob patterns match files. Defaults to `{ matchBase: true }`.
 
 For more options, see [clean-css](https://github.com/jakubpawlowicz/clean-css).
 
@@ -74,6 +76,7 @@ neat_js:
 - **mangle** - Mangle variable names. Defaults to `true`. Pass an object to specify [mangle options](https://github.com/terser-js/terser#mangle-options).
 - **output** - Output options.
   - To retain comments, `output: {comments: true}`.
+- **globOptions** - [micromatch options](https://github.com/micromatch/micromatch#options) to customise how glob patterns match files. Defaults to `{ matchBase: true }`.
 
 For more options, see [Terser](https://github.com/terser-js/terser).
 
@@ -92,6 +95,7 @@ neat_svg:
   - Exclude `*.min.svg` by default.
 - **plugins** - Plugin options.
   - To retain comments, `plugins: [{removeComments: false}]`.
+- **globOptions** - [micromatch options](https://github.com/micromatch/micromatch#options) to customise how glob patterns match files. Defaults to `{ matchBase: true }`.
 
 For more options, see [svgo](https://github.com/svg/svgo).
 
@@ -118,6 +122,7 @@ neat_gzip:
 - **include** - Include files. Support wildcard pattern.
   - Support one-liner, `include: ['*.html','*.css','*.js']`.
   - Must include asterisk and single quotes. `.html` is invalid. `'*.html'` is valid.
+- **globOptions** - [micromatch options](https://github.com/micromatch/micromatch#options) to customise how glob patterns match files. Defaults to `{ matchBase: true }`.
 
 ----------
 
@@ -140,6 +145,7 @@ neat_brotli:
 - **enable** - Enable the plugin. Defaults to `true`.
 - **logger** - Verbose output. Defaults to `false`.
 - **include** - Include files. Support wildcard pattern.
+- **globOptions** - [micromatch options](https://github.com/micromatch/micromatch#options) to customise how glob patterns match files. Defaults to `{ matchBase: true }`.
 
 ## HTTP Compression
 While most modern web browsers [support Brotli](https://www.caniuse.com/#feat=brotli), you also need to consider whether the web/app server, hosting platform, reverse proxy or CDN (whichever relevant to you) support it.

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ if (hexo.config.neat_enable === true) {
     removeScriptTypeAttributes: true,
     removeStyleLinkTypeAttributes: true,
     minifyJS: true,
-    minifyCSS: true
+    minifyCSS: true,
+    globOptions: { matchBase: true }
   }, hexo.config.neat_html)
 
   // CSS minifier
@@ -24,7 +25,8 @@ if (hexo.config.neat_enable === true) {
     enable: true,
     logger: false,
     exclude: ['*.min.css'],
-    level: 2
+    level: 2,
+    globOptions: { matchBase: true }
   }, hexo.config.neat_css)
 
   // Javascript minifier
@@ -34,7 +36,8 @@ if (hexo.config.neat_enable === true) {
     exclude: ['*.min.js'],
     compress: {},
     mangle: true,
-    output: {}
+    output: {},
+    globOptions: { matchBase: true }
   }, hexo.config.neat_js)
 
   // SVG minifier
@@ -42,21 +45,24 @@ if (hexo.config.neat_enable === true) {
     enable: true,
     logger: false,
     include: ['*.svg', '!*.min.svg'],
-    plugins: []
+    plugins: [],
+    globOptions: { matchBase: true }
   }, hexo.config.neat_svg)
 
   // gzip compression
   hexo.config.neat_gzip = Object.assign({
     enable: true,
     logger: false,
-    include: ['*.html', '*.css', '*.js', '*.txt', '*.ttf', '*.atom', '*.stl', '*.xml', '*.svg', '*.eot', '*.json']
+    include: ['*.html', '*.css', '*.js', '*.txt', '*.ttf', '*.atom', '*.stl', '*.xml', '*.svg', '*.eot', '*.json'],
+    globOptions: { matchBase: true }
   }, hexo.config.neat_gzip)
 
   // brotli compression
   hexo.config.neat_brotli = Object.assign({
     enable: true,
     logger: false,
-    include: ['*.html', '*.css', '*.js', '*.txt', '*.ttf', '*.atom', '*.stl', '*.xml', '*.svg', '*.eot', '*.json']
+    include: ['*.html', '*.css', '*.js', '*.txt', '*.ttf', '*.atom', '*.stl', '*.xml', '*.svg', '*.eot', '*.json'],
+    globOptions: { matchBase: true }
   }, hexo.config.neat_brotli)
 
   const filter = require('./lib/filter')

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,13 +1,20 @@
-/* global hexo */
 'use strict'
 
 const Htmlminifier = require('html-minifier').minify
 const CleanCSS = require('clean-css')
 const Terser = require('terser')
-const svgo = require('svgo')
+const Svgo = require('svgo')
 const zlib = require('zlib')
 const br = require('iltorb')
-const nanomatch = require('nanomatch')
+const micromatch = require('micromatch')
+
+function isMatch (path, patterns, options) {
+  if (path && patterns && patterns.length) {
+    return micromatch.isMatch(path, patterns, options)
+  } else {
+    return false
+  }
+}
 
 function logicHtml (str, data) {
   const hexo = this
@@ -15,13 +22,12 @@ function logicHtml (str, data) {
   // Return if disabled.
   if (options.enable === false) return
 
-  let path = data.path
-  let exclude = options.exclude
+  const path = data.path
+  const exclude = options.exclude
+  const globOptions = options.globOptions
 
   // Return if a path matches exclusion pattern
-  if (path && exclude && exclude.length) {
-    if (nanomatch.some(path, exclude, { matchBase: true })) return str
-  }
+  if (isMatch(path, exclude, globOptions)) return str
 
   let result = Htmlminifier(str, options)
   let saved = ((str.length - result.length) / str.length * 100).toFixed(2)
@@ -35,16 +41,13 @@ function logicHtml (str, data) {
 function logicCss (str, data) {
   const hexo = this
   const options = hexo.config.neat_css
-  // Return if disabled.
   if (options.enable === false) return
 
-  let path = data.path
-  let exclude = options.exclude
+  const path = data.path
+  const exclude = options.exclude
+  const globOptions = options.globOptions
 
-  // Return if a path matches exclusion pattern
-  if (path && exclude && exclude.length) {
-    if (nanomatch.some(path, exclude, { matchBase: true })) return str
-  }
+  if (isMatch(path, exclude, globOptions)) return str
 
   return new Promise((resolve, reject) => {
     new CleanCSS(options).minify(str, (err, result) => {
@@ -62,22 +65,20 @@ function logicCss (str, data) {
 function logicJs (str, data) {
   const hexo = this
   const options = hexo.config.neat_js
-  // Return if disabled.
   if (options.enable === false) return
 
-  let path = data.path
-  let exclude = options.exclude
+  const path = data.path
+  const exclude = options.exclude
+  const globOptions = options.globOptions
 
-  // Return if a path matches exclusion pattern
-  if (path && exclude && exclude.length) {
-    if (nanomatch.some(path, exclude, { matchBase: true })) return str
-  }
+  if (isMatch(path, exclude, globOptions)) return str
 
   // Terser doesn't like unsupported options
   const jsOptions = Object.assign({}, options)
   delete jsOptions.enable
   delete jsOptions.exclude
   delete jsOptions.logger
+  delete jsOptions.globOptions
 
   let result = Terser.minify(str, jsOptions)
   let saved = ((str.length - result.code.length) / str.length * 100).toFixed(2)
@@ -97,8 +98,9 @@ function logicSvg () {
   let route = hexo.route
   let routeList = route.list()
   let include = options.include
+  const globOptions = options.globOptions
 
-  return Promise.all((nanomatch(routeList, include, { matchBase: true })).map(path => {
+  return Promise.all((micromatch(routeList, include, globOptions)).map(path => {
     return new Promise((resolve, reject) => {
       // Grab all assets using hexo router
       let assetPath = route.get(path)
@@ -108,7 +110,7 @@ function logicSvg () {
       assetPath.on('end', () => {
         if (assetTxt.length) {
           // Minify using svgo
-          new svgo(options).optimize(assetTxt).then((result) => {
+          new Svgo(options).optimize(assetTxt).then((result) => {
             // Replace the original file with the minified.
             route.set(path, result.data)
             // Logging
@@ -134,8 +136,9 @@ function logicGzip () {
   let route = hexo.route
   let routeList = route.list()
   let include = options.include
+  const globOptions = options.globOptions
 
-  return Promise.all((nanomatch(routeList, include, { matchBase: true })).map(path => {
+  return Promise.all((micromatch(routeList, include, globOptions)).map(path => {
     return new Promise((resolve, reject) => {
       // Grab all assets using hexo router
       let assetPath = route.get(path)
@@ -175,8 +178,9 @@ function logicBrotli () {
   let route = hexo.route
   let routeList = route.list()
   let include = options.include
+  const globOptions = options.globOptions
 
-  return Promise.all((nanomatch(routeList, include, { matchBase: true })).map(path => {
+  return Promise.all((micromatch(routeList, include, globOptions)).map(path => {
     return new Promise((resolve, reject) => {
       // Grab all assets using hexo router
       let assetPath = route.get(path)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "clean-css": "^4.2.1",
     "html-minifier": "^4.0.0",
     "iltorb": "^2.4.2",
-    "nanomatch": "^1.2.13",
+    "micromatch": "^4.0.2",
     "svgo": "^1.2.2",
     "terser": "^4.0.0"
   },


### PR DESCRIPTION
* micromatch supports more patterns
  - https://github.com/micromatch/picomatch#library-comparisons
* hexo recently switched to it
  - https://github.com/hexojs/hexo/pull/3538
* refactor repeating micromatch.isMatch() to isMatch() global function
* introduce globOptions
  - inspired by https://github.com/okonet/lint-staged/pull/179